### PR TITLE
Add regex matching support

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,6 +2,7 @@ en:
   site_settings:
     file_attachment_whispers_enabled: "Enable to remove restricted file types from a post and move to a whisper"
     file_attachment_whispers_file_extensions: "List of extensions to extract from a post"
+    file_attachment_whispers_regex: "Regex to extract from a post"
     file_attachment_whispers_message: "Message to display in a topic upon removal"
     file_attachment_whispers_notify: "Enable to add a whisper with the extracted files"
     file_attachment_whispers_staff_bypass: "Enable to allow staff members to bypass filtering"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,10 @@ plugins:
     client: true
   file_attachment_whispers_file_extensions:
     type: 'list'
-    default: 'none'
+    default: ''
+  file_attachment_whispers_regex:
+    type: 'string'
+    default: ''
   file_attachment_whispers_message:
     default: 'MOVED TO STAFF NOTE'
     client: true


### PR DESCRIPTION
1. В текущем виде плагин проверяет вхождение сконфигуренных строк в URL (href). Но URL предсттавляет собой `https://support.wirenboard.com/uploads/short-url/<hash>.zip`, то есть нет возможности дополнительно сматчить `diag_output_` префикс. Можно только скрыть все zip аттачи разом.
2. Исходное название аттача можно извлечь из inner_html вместо href (`<a class="attachment" href="<path>/<hash>.zip">diag_output_<...>.zip</a>`)
3. Добавил доп опцию `file_attachment_whispers_regex`, если сконфигурено, то пробует сматчить то самое inner_html в `<a>...</a>` блоке, если не сконфигурено или регекс невалидный - игнорим.

Как проверить в локальной песочнице: https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009