### PR TITLE
Show replaced text as grey+italic

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -51,7 +51,7 @@ after_initialize do
                     links.push(attachment)
                     node = post_html.create_element 'p'# create paragraph element
                     node.inner_html = SiteSetting.file_attachment_whispers_message
-                    attachment.replace '<font color="red">' + node + '</font>'
+                    attachment.replace '<div class="d-wrap" data-wrap="color" data-color="grey"><i>' + node + '</i></div>'
 
                     # remove extra tags nokogiri adds in
                     index1 = post_html.to_s.index('body')


### PR DESCRIPTION
Dark theme:
<img width="994" alt="Näyttökuva 2023-4-27 kello 23 11 19" src="https://user-images.githubusercontent.com/688044/234968093-7bdfa5e6-df07-4598-bdd6-ca2c1dc0222b.png">
Light theme:
<img width="1004" alt="Näyttökuva 2023-4-27 kello 23 11 57" src="https://user-images.githubusercontent.com/688044/234968100-df66b58b-bb86-488b-9d8f-41d64aff1ff4.png">

Requirements:
 * [Discourse Colored Text](https://meta.discourse.org/t/discourse-coloured-text/218111) theme component enabled:
<img width="1102" alt="Näyttökuva 2023-4-27 kello 23 23 08" src="https://user-images.githubusercontent.com/688044/234970024-be059c29-50d2-469f-9b5e-840dee4b5419.png">
